### PR TITLE
Add a paged consumer feed over verified crawler diffs

### DIFF
--- a/backend/DOCS.md
+++ b/backend/DOCS.md
@@ -6,6 +6,9 @@ for consolidation (NDJSON → parquet). No central database: each board is its o
 
 Production: `https://backend.dehnbostele.workers.dev`
 
+Optional public snapshot deltas: [Job changes feed](JOB-CHANGES.md) describes publishing
+and consuming additions, edits and dataset removals without re-downloading all group files.
+
 ## Architecture
 
 ```

--- a/backend/DOCS.md
+++ b/backend/DOCS.md
@@ -6,7 +6,7 @@ for consolidation (NDJSON → parquet). No central database: each board is its o
 
 Production: `https://backend.dehnbostele.workers.dev`
 
-Optional public snapshot deltas: [Job changes feed](JOB-CHANGES.md) describes publishing
+Optional paged crawler-diff projection: [Job changes feed](JOB-CHANGES.md) describes publishing
 and consuming additions, edits and dataset removals without re-downloading all group files.
 
 ## Architecture

--- a/backend/JOB-CHANGES.md
+++ b/backend/JOB-CHANGES.md
@@ -1,0 +1,93 @@
+# Public job changes (opt-in publisher)
+
+Consumers that filter jobs locally currently need to download the group corpus again after each
+rebuild: leaf IDs and membership change during clustering. This optional feed publishes additions,
+edits and dataset removals once per completed snapshot, without embeddings or per-reader Board DO
+queries. It uses the existing public `/data/*` route; no new Worker binding or database is needed.
+
+## Publish
+
+After `build-manifest.py` finishes, from `backend/`:
+
+```sh
+# First publication: all current jobs become upserts.
+python3 scripts/build-job-changes.py --web export/2026-09-07/web \
+  --publish-base https://backend.dehnbostele.workers.dev
+
+# Subsequent publication: use the last SUCCESSFULLY PUBLISHED export, not export/latest.
+python3 scripts/build-job-changes.py --web export/2026-09-08/web \
+  --previous-web export/2026-09-07/web \
+  --publish-base https://backend.dehnbostele.workers.dev
+```
+
+Omit `--publish-base` to build locally without network access. Publishing uses the existing
+Wrangler credentials and `jobscream-data` bucket. The supplied Worker URL must serve that bucket.
+This is opt-in: the existing consolidation/upload commands and production schedule are unchanged.
+The maintainer can add this command after a successful daily consolidation when ready to enable it.
+
+Run exactly one publisher at a time (use the scheduler's single-run lock). The remote-parent
+checks detect stale exports and most accidental overlap; they are **not** an atomic distributed
+lock. Preserve the last published export, including its groups and `changes/latest.json`, separately
+from the next run. Do not overwrite it during a same-day consolidation rerun. The builder verifies
+the previous projection's digest, both manifests' counts, group membership and unique job keys.
+
+Pages are uploaded first, then their immutable generation manifest, then `changes/latest.json`.
+Any failed upload stops publication. The final pointer is read back before reporting success.
+Retry the same preserved inputs after a failure; the generation and page hashes are deterministic.
+If the pointer was already published before an interruption, retrying that generation is safe.
+If inputs changed after an uncertain publication, recover the export matching the remote head
+before continuing. Never bootstrap over an existing feed or silently create a disconnected chain.
+
+## Consume
+
+1. GET `/data/changes/latest.json` (use its ETag for subsequent `If-None-Match` requests).
+2. Follow `previous` through `/data/changes/<generation>/manifest.json` until reaching your saved
+   generation, or `null` on first sync. Pin the head from step 1 while catching up.
+3. Apply the collected generations oldest first. Fetch each page at
+   `/data/changes/<generation>/<file>`, checking `bytes` and `sha256` before applying it.
+4. Upsert by `key`, and remove by `key`. Save the generation checkpoint only after all its pages
+   are applied. Replaying pages is idempotent. A zero-page generation still advances the checkpoint.
+
+The generation is an opaque cursor, not a wall-clock query. `snapshot_at` is the source manifest's
+Unix milliseconds. `previous: null` denotes a bootstrap containing the complete initial projection.
+The first sync must read that bootstrap and intervening deltas; later syncs read only new deltas.
+Pages contain at most 1,000 records and 4 MiB; oversized individual records fail the build.
+
+```json
+{"op":"upsert","key":"example/company#123","job":{"ats":"example","slug":"company","id":"123","title":"Engineer","location":"Phoenix, AZ","seen":1788740796163,"pub":1788740796163,"jd":"..."}}
+{"op":"remove","key":"example/company#456"}
+```
+
+Upserts contain the public fields `ats`, `slug`, `id`, `title`, `company`, `location`, `url`,
+`seen`, `pub`, `jd` when present. `seen` is first-seen time, not last crawl time. Vector changes,
+leaf reassignment, enrichment and company metadata outside this projection do not create events.
+Location edits do create events, so consumers can remove jobs that stop matching their city filter.
+
+**A remove means absent from the published embedded-job dataset, not confirmed closed.** Embedding
+eligibility and upstream coverage can also change membership. Use `/status` for authoritative
+open/removed/unknown checks before making closure claims. This is a daily snapshot diff, not a
+complete history of changes between snapshots, and incomplete upstream coverage cannot be detected
+merely by validating a locally consistent manifest.
+
+Keep every published generation reachable from the head. This first version has no pruning or
+compacted bootstrap rotation. If a required manifest/page is missing, stop and request a fresh
+bootstrap; never skip the gap or advance the cursor. The existing `/data/*` cache can delay visibility
+of a new head by up to an hour, without breaking the immutable chain.
+
+## Cost and verification
+
+Publisher work is two sequential corpus reads, indexed local SQLite comparison and temporary disk
+space proportional to the text projection. Memory holds one group and one bounded output page.
+Readers use R2 reads proportional to changed pages and missed generations, with no DO fan-out,
+database scans, model calls or vectors. Storage grows with the initial projection plus retained
+changes. At 10x changes, page reads/writes and retained delta bytes grow roughly 10x; an unusually
+large source correction can still produce a nearly full-corpus delta.
+
+```sh
+python3 -m unittest discover -s scripts -p test_job_changes.py -v
+```
+
+Tests cover bootstrap/delta replay, reclustering, projection exclusions, incomplete input, duplicate
+keys, previous-content drift, page limits, deterministic retries, failed uploads, stale parents,
+corrupt pages and publication order. Publication tests use a fake object store; they do not upload
+production data.

--- a/backend/JOB-CHANGES.md
+++ b/backend/JOB-CHANGES.md
@@ -1,93 +1,169 @@
-# Public job changes (opt-in publisher)
+# Public job changes (opt-in publisher, v2)
 
-Consumers that filter jobs locally currently need to download the group corpus again after each
-rebuild: leaf IDs and membership change during clustering. This optional feed publishes additions,
-edits and dataset removals once per completed snapshot, without embeddings or per-reader Board DO
-queries. It uses the existing public `/data/*` route; no new Worker binding or database is needed.
+This is the small-page consumer layer over `build-diff.py`, not a second corpus diff.
+It uses the existing `/data/*` route and requires no new Worker, database, Board DO calls,
+or model requests. The publisher reads the verified **lite** parquet parts once for projection
+(plus streaming checksum passes). Ordinary readers download only new NDJSON pages.
 
-## Publish
+## Dataset and fields
 
-After `build-manifest.py` finishes, from `backend/`:
+`scope: crawler-export-v1` means the open-job crawler export, including jobs not yet embedded.
+Both bootstrap and deltas use that same scope. It is **not** a byte-for-byte mirror of the
+embedded/model-filtered `groups/` dataset. Mixing a groups-only bootstrap with unrestricted
+crawler deltas would miss unchanged, unembedded jobs and drift as model eligibility changes.
+Consumers needing the exact search-group membership must continue using that dataset.
 
-```sh
-# First publication: all current jobs become upserts.
-python3 scripts/build-job-changes.py --web export/2026-09-07/web \
-  --publish-base https://backend.dehnbostele.workers.dev
+The operation mapping is:
 
-# Subsequent publication: use the last SUCCESSFULLY PUBLISHED export, not export/latest.
-python3 scripts/build-job-changes.py --web export/2026-09-08/web \
-  --previous-web export/2026-09-07/web \
-  --publish-base https://backend.dehnbostele.workers.dev
-```
+| Source | Feed |
+| --- | --- |
+| `added`, `changed` | `upsert` with the projected current row |
+| `removed` | `remove`, preserving `removal` and `removed_at_crawler` |
+| `carried`, `changed_prev` | No event |
 
-Omit `--publish-base` to build locally without network access. Publishing uses the existing
-Wrangler credentials and `jobscream-data` bucket. The supplied Worker URL must serve that bucket.
-This is opt-in: the existing consolidation/upload commands and production schedule are unchanged.
-The maintainer can add this command after a successful daily consolidation when ready to enable it.
+Every upsert includes `ats`, `slug`, `id`, `title`, `location`, `url`, `content`,
+`embed_status`, `published_at`, and `first_seen_at`. Dates are UTC ISO-8601 strings or null.
+Null content is normalized to an empty string, matching upstream change-key semantics.
+The upstream `change_key` must cover all six mutable projected fields: title, location,
+URL, content, embedding status and published date. Identities and first-seen dates are
+treated as stable; upstream first-seen corrections require a fresh bootstrap.
 
-Run exactly one publisher at a time (use the scheduler's single-run lock). The remote-parent
-checks detect stale exports and most accidental overlap; they are **not** an atomic distributed
-lock. Preserve the last published export, including its groups and `changes/latest.json`, separately
-from the next run. Do not overwrite it during a same-day consolidation rerun. The builder verifies
-the previous projection's digest, both manifests' counts, group membership and unique job keys.
+Company names are intentionally **not** emitted: board metadata is not part of the source
+change key. This avoids silently presenting stale names as fully synchronized data.
+Consumers can maintain board/company metadata separately. Adding resolved company names to
+this feed requires the upstream board-to-row propagation and change detection Elliott offered.
+Departments, enrichment, last crawl time, updated time, vectors and model IDs are also excluded.
+An embedding-status transition is an upsert, not a closure. A city-filtered consumer must
+remove a locally retained job when an upsert stops matching its filter.
 
-Pages are uploaded first, then their immutable generation manifest, then `changes/latest.json`.
-Any failed upload stops publication. The final pointer is read back before reporting success.
-Retry the same preserved inputs after a failure; the generation and page hashes are deterministic.
-If the pointer was already published before an interruption, retrying that generation is safe.
-If inputs changed after an uncertain publication, recover the export matching the remote head
-before continuing. Never bootstrap over an existing feed or silently create a disconnected chain.
+All removal reasons delete the row from a dataset mirror. `closed` reports the same-run
+ledger's closed state; `left_dataset` reports a crawler-open job absent from the export;
+`unknown` means no usable ledger record. The page layer does not infer a closure from missing
+rows or a partial board pull. The reasons are only as complete/fresh as the upstream ledger.
+Use `/status` for a current status check when needed. Daily exports do not capture transient
+changes between builds.
 
-## Consume
+## Build and publish
 
-1. GET `/data/changes/latest.json` (use its ETag for subsequent `If-None-Match` requests).
-2. Follow `previous` through `/data/changes/<generation>/manifest.json` until reaching your saved
-   generation, or `null` on first sync. Pin the head from step 1 while catching up.
-3. Apply the collected generations oldest first. Fetch each page at
-   `/data/changes/<generation>/<file>`, checking `bytes` and `sha256` before applying it.
-4. Upsert by `key`, and remove by `key`. Save the generation checkpoint only after all its pages
-   are applied. Replaying pages is idempotent. A zero-page generation still advances the checkpoint.
-
-The generation is an opaque cursor, not a wall-clock query. `snapshot_at` is the source manifest's
-Unix milliseconds. `previous: null` denotes a bootstrap containing the complete initial projection.
-The first sync must read that bootstrap and intervening deltas; later syncs read only new deltas.
-Pages contain at most 1,000 records and 4 MiB; oversized individual records fail the build.
-
-```json
-{"op":"upsert","key":"example/company#123","job":{"ats":"example","slug":"company","id":"123","title":"Engineer","location":"Phoenix, AZ","seen":1788740796163,"pub":1788740796163,"jd":"..."}}
-{"op":"remove","key":"example/company#456"}
-```
-
-Upserts contain the public fields `ats`, `slug`, `id`, `title`, `company`, `location`, `url`,
-`seen`, `pub`, `jd` when present. `seen` is first-seen time, not last crawl time. Vector changes,
-leaf reassignment, enrichment and company metadata outside this projection do not create events.
-Location edits do create events, so consumers can remove jobs that stop matching their city filter.
-
-**A remove means absent from the published embedded-job dataset, not confirmed closed.** Embedding
-eligibility and upstream coverage can also change membership. Use `/status` for authoritative
-open/removed/unknown checks before making closure claims. This is a daily snapshot diff, not a
-complete history of changes between snapshots, and incomplete upstream coverage cannot be detected
-merely by validating a locally consistent manifest.
-
-Keep every published generation reachable from the head. This first version has no pruning or
-compacted bootstrap rotation. If a required manifest/page is missing, stop and request a fresh
-bootstrap; never skip the gap or advance the cursor. The existing `/data/*` cache can delay visibility
-of a new head by up to an hour, without breaking the immutable chain.
-
-## Cost and verification
-
-Publisher work is two sequential corpus reads, indexed local SQLite comparison and temporary disk
-space proportional to the text projection. Memory holds one group and one bounded output page.
-Readers use R2 reads proportional to changed pages and missed generations, with no DO fan-out,
-database scans, model calls or vectors. Storage grows with the initial projection plus retained
-changes. At 10x changes, page reads/writes and retained delta bytes grow roughly 10x; an unusually
-large source correction can still produce a nearly full-corpus delta.
+Run from `backend/`, with Python 3.10+ and DuckDB (`uv` installs the script dependency):
 
 ```sh
-python3 -m unittest discover -s scripts -p test_job_changes.py -v
+# After a successful, serialized consolidation/upload-history run, save the public index.
+# Use a cache-busted request; retain this file with the build inputs until validation finishes.
+curl --fail "https://backend.dehnbostele.workers.dev/data/diffs/index.json?check=$(date +%s)" \
+  -o export/diffs-index.json
+
+# Bootstrap at September 8 or later: earlier ledgers were incomplete.
+uv run scripts/build-job-changes.py --out export/feed \
+  --snapshot export/2026-09-08 --index export/diffs-index.json \
+  --publish-base https://backend.dehnbostele.workers.dev
+
+# Next day: previous is the successful publication receipt, not changes/latest.json.
+uv run scripts/build-job-changes.py --out export/feed \
+  --diff export/diffs/2026-09-08__2026-09-09.json --previous export/feed/published.json \
+  --publish-base https://backend.dehnbostele.workers.dev
 ```
 
-Tests cover bootstrap/delta replay, reclustering, projection exclusions, incomplete input, duplicate
-keys, previous-content drift, page limits, deterministic retries, failed uploads, stale parents,
-corrupt pages and publication order. Publication tests use a fake object store; they do not upload
-production data.
+These dates are examples; use the actual completed export and consecutive diff. Bootstrap
+requires an index head matching the export directory date, matching `snapshot_built_at` and
+local manifest timestamp, one diff anchor ending at that date, and the full post-carry row
+count. It fingerprints all input parquet parts before/after projection, validates unique
+keys, and freezes the projected snapshot into immutable pages tied to an exact source cursor.
+It does not read the vectors into Python. It trusts the publisher's completed export and
+matching index provenance; counts and timestamps alone cannot prove a crawler pull was complete.
+
+Deltas require completed v2 sidecars, matching `from` and parent content hash, valid full-part
+digest descriptors, and matching lite-part sizes/hashes. Every part, source op/date, event
+count, unique operation and paired changed/changed_prev key is checked. Unknown ops, gaps,
+duplicates, conflicting rows and incomplete carries fail before producing a candidate head.
+Only the previous feed **manifest** is needed; no previous web directory or full export.
+
+Omit `--publish-base` for an offline build. Output is under `export/feed/changes/`, outside
+daily export retention. `changes/latest.json` is only a local candidate. `published.json` is
+updated atomically only after successful remote pointer readback. Publishing uses existing
+Wrangler credentials and `jobscream-data`; the Worker URL must serve that bucket.
+Production consolidation and schedules remain opt-in and unchanged.
+
+Run exactly one publisher, serialized with consolidation. Source checks detect some concurrent
+changes but do not replace a lock. Validate local pages and manifest, upload pages, upload their
+immutable manifest, recheck the remote parent, then advance `changes/latest.json` and read it back.
+The stale-parent checks are not atomic compare-and-swap or a distributed lock.
+
+After an interrupted/uncertain upload, retry the **same candidate**, even if the old full export
+has already been pruned:
+
+```sh
+uv run scripts/build-job-changes.py --out export/feed \
+  --candidate export/feed/changes/GENERATION/manifest.json \
+  --publish-base https://backend.dehnbostele.workers.dev
+```
+
+This validates/reuploads the preserved pages without rerunning the source pipeline. Replaying
+an already-published candidate is safe. Do not rebuild against the new receipt merely to retry.
+An unexpected remote head requires reconciling that head, never overwriting it. Keep candidate
+pages and all published generations indefinitely, consistent with the upstream history policy.
+The unpublished v1 group-diff proposal is not wire-compatible; v2 refuses v1 manifests.
+
+## Consume and recover
+
+1. Read `/data/changes/latest.json`, pin that head, and validate its `generation` as SHA256 of
+   canonical JSON of all other fields (sorted keys, compact separators, UTF-8, no ASCII escaping).
+2. Follow `previous` via `/data/changes/GENERATION/manifest.json` to the saved generation.
+   On first sync, stop at the nearest `kind: bootstrap`. Verify every manifest hash and link.
+3. Apply generations oldest first, verifying each page's `bytes`, SHA256 and row count.
+   Pages contain at most 1,000 rows and 4 MiB. Oversized individual records fail publication.
+4. Upsert or delete by `ats/slug#id`. Commit all pages and the checkpoint atomically. A zero-page
+   delta still advances the checkpoint. Retrying the same generation is a no-op; replaying an
+   individual operation is idempotent.
+
+`generation` is the opaque integrity/replay cursor; `cursor` is its upstream export date and
+`source` is the exact upstream diff name/content hash. They serve different purposes. A date
+alone does not identify a rebuilt bootstrap. Delta headers also pin a canonical sidecar hash.
+`snapshot_at` is the bootstrap manifest's build time; it is null on deltas, which only assert
+the source export date.
+
+The callable `apply_generation(db, folder, header, reset=False)` is a small SQLite reference
+consumer used by the tests. It verifies pages inside a transaction and rolls back both data
+and checkpoint on corruption. A bootstrap over existing state requires explicit `reset=True`.
+Consumers adapting it for their own persistence must retain those transaction semantics.
+
+History does not expire. If any required page/manifest/diff is missing or corrupt, stop and
+leave the checkpoint unchanged. First retry transient fetch errors; never skip a gap. For
+unrecoverable gaps, the publisher can make a fresh bootstrap from the current completed export
+using `--snapshot`, the matching `--index`, and `--previous export/feed/published.json`. This
+retains the previous link while providing a new full recovery boundary. Consumers explicitly
+replace their local scope from that verified bootstrap and continue with later deltas. The
+tests exercise this replacement and removal of stale local rows. There is no automatic pruning
+or periodic full-bootstrap job. Do not mix this feed with the mutable groups bootstrap.
+
+The existing `/data/*` cache may delay discovery of a new head. Use cache busting/no-cache for
+publication readback; consumers may use ETags/conditional GETs for ordinary polling.
+
+## Verification, portability and costs
+
+```sh
+uv run --with duckdb python -m unittest discover -s scripts -p test_job_changes.py -v
+
+# Same fixtures in a provider-independent OCI runtime; no Cloudflare credentials needed.
+docker run --rm -v "$PWD:/work" -w /work python:3.11-slim sh -c \
+  'pip install duckdb && python -m unittest discover -s scripts -p test_job_changes.py -v'
+```
+
+The tests build real synthetic parquet and run the upstream diff SQL, including carry-forward,
+all tracked field changes and ledger-based removal. They cover bootstrap alignment/cutoff,
+replay, fresh recovery, gaps, incomplete/duplicate/conflicting input, source and page corruption,
+bounded pages, every publication failure stage, stale parents, concurrency and readback.
+The removal SQL test also guards the qualified-column fix required by the new ledger join.
+
+At 1x, bootstrap requires one full projected export plus checksum reads and temporary SQLite
+space; expected daily runs read only lite diffs, with local disk proportional to changed records.
+DuckDB is limited to 512 MiB and Python streams small batches plus one bounded page. Source
+decoding still needs room for an individual input record. There are no Neon queries or writes.
+Readers pay for changed page downloads, not embeddings or Board DO requests. At 10x changes,
+page I/O, temporary disk and retained delta storage grow approximately 10x. A large correction
+can approach a full export; a recovery bootstrap is deliberately an exceptional full read.
+
+The core is local Python/DuckDB/SQLite and static JSON/NDJSON. Replace the `put`/`remote_head`
+transport functions with an S3-compatible or filesystem/HTTP publisher to move providers;
+the same fake-store publication and transactional replay fixtures apply. No production upload,
+deployment or crawler scheduling change is part of this PR.

--- a/backend/scripts/build-diff.py
+++ b/backend/scripts/build-diff.py
@@ -54,6 +54,7 @@ con.execute(f"CREATE VIEW old AS SELECT * FROM read_parquet('{prev}/jobs/*.parqu
 con.execute(f"CREATE VIEW new AS SELECT * FROM read_parquet('{new}/jobs/*.parquet', union_by_name=true)")
 cols = [r[0] for r in con.execute("DESCRIBE new").fetchall()]
 collist = ", ".join(f'"{c}"' for c in cols)
+old_collist = ", ".join(f'o."{c}"' for c in cols)
 
 # narrow key tables first; the wide rows are only touched once, in the final COPY
 # "changed" = a visible field moved. Not content_hash: the crawler hashes the provider's raw payload too, and
@@ -120,7 +121,7 @@ if os.path.isdir(outd):
     for f in glob.glob(os.path.join(outd, "*.parquet")): os.remove(f)
 con.execute(f"""COPY (
   SELECT 'added' AS op, '{pd}' AS from_date, '{nd}' AS to_date, NULL::VARCHAR AS removal, NULL::TIMESTAMPTZ AS removed_at_crawler, {collist} FROM new n WHERE EXISTS (SELECT 1 FROM addk k WHERE k.ats=n.ats AND k.slug=n.slug AND k.id=n.id)
-  UNION ALL SELECT 'removed', '{pd}', '{nd}', {removal_sql}, led.removed_at, {collist} FROM old o JOIN remk k ON k.ats=o.ats AND k.slug=o.slug AND k.id=o.id LEFT JOIN led ON led.ats=o.ats AND led.slug=o.slug AND led.id=o.id
+  UNION ALL SELECT 'removed', '{pd}', '{nd}', {removal_sql}, led.removed_at, {old_collist} FROM old o JOIN remk k ON k.ats=o.ats AND k.slug=o.slug AND k.id=o.id LEFT JOIN led ON led.ats=o.ats AND led.slug=o.slug AND led.id=o.id
   UNION ALL SELECT 'changed', '{pd}', '{nd}', NULL, NULL, {collist} FROM new n WHERE EXISTS (SELECT 1 FROM chgk k WHERE k.ats=n.ats AND k.slug=n.slug AND k.id=n.id)
   UNION ALL SELECT 'changed_prev', '{pd}', '{nd}', NULL, NULL, {collist} FROM old o WHERE EXISTS (SELECT 1 FROM chgk k WHERE k.ats=o.ats AND k.slug=o.slug AND k.id=o.id)
   UNION ALL SELECT 'carried', '{pd}', '{nd}', NULL, NULL, {collist} FROM old o WHERE EXISTS (SELECT 1 FROM carryk k WHERE k.ats=o.ats AND k.slug=o.slug AND k.id=o.id)

--- a/backend/scripts/build-job-changes.py
+++ b/backend/scripts/build-job-changes.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Build/publish a public snapshot change feed. Standard library only; see JOB-CHANGES.md."""
+import argparse
+from contextlib import closing
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import sqlite3
+import subprocess
+import tempfile
+import urllib.error
+import urllib.request
+import uuid
+
+FIELDS = ('ats', 'slug', 'id', 'title', 'company', 'location', 'url', 'seen', 'pub', 'jd')
+MAX_ROWS = 1000
+MAX_BYTES = 4 * 1024 * 1024
+
+
+def encode(value):
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=False,
+                      allow_nan=False).encode('utf-8')
+
+
+def digest(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def read_json(path):
+    return json.loads(Path(path).read_text(encoding='utf-8'))
+
+
+def load_snapshot(db, table, web):
+    """One group in memory at a time; stale, unreferenced group files are ignored."""
+    manifest = read_json(web / 'manifest.json')
+    leaves = [n for n in manifest['tree'] if not n['children']]
+    ids = [n['id'] for n in leaves]
+    if (any(type(i) is not int or i < 0 for i in ids) or len(set(ids)) != len(ids)
+            or len(ids) != manifest['leaves'] or not ids):
+        raise ValueError('invalid or empty manifest leaves')
+    count = 0
+    for leaf in leaves:
+        group = read_json(web / 'groups' / f"{leaf['id']}.json")
+        if group['leaf'] != leaf['id'] or len(group['jobs']) != leaf['size']:
+            raise ValueError('incomplete or mismatched group')
+        for job in group['jobs']:
+            if any(not isinstance(job.get(k), str) or not job[k] for k in ('ats', 'slug', 'id')):
+                raise ValueError('invalid job identity')
+            key = f"{job['ats']}/{job['slug']}#{job['id']}"
+            payload = encode({k: job[k] for k in FIELDS if k in job}).decode('utf-8')
+            # Duplicate identities fail closed rather than emitting ambiguous removals/updates.
+            db.execute(f'INSERT INTO {table} VALUES (?, ?)', (key, payload))
+            count += 1
+    if count != manifest['jobs'] or count != sum(n['size'] for n in leaves):
+        raise ValueError('incomplete snapshot job count')
+    db.commit()
+    return manifest
+
+
+def snapshot_digest(db, table):
+    checksum = hashlib.sha256()
+    for key, payload in db.execute(f'SELECT key,payload FROM {table} ORDER BY key'):
+        checksum.update(encode([key, payload]) + b'\n')
+    return checksum.hexdigest()
+
+
+def build(web, previous_web=None):
+    web = Path(web).resolve()
+    previous_web = Path(previous_web).resolve() if previous_web else None
+    if web == previous_web:
+        raise ValueError('previous snapshot must be a separate preserved directory')
+    previous = read_json(previous_web / 'changes/latest.json') if previous_web else None
+    if previous and previous.get('version') != 1:
+        raise ValueError('unsupported previous feed version')
+    with tempfile.TemporaryDirectory(prefix='job-changes-') as scratch:
+        scratch = Path(scratch)
+        with closing(sqlite3.connect(scratch / 'jobs.sqlite')) as db:
+            for table in ('old', 'new'):
+                db.execute(f'CREATE TABLE {table} (key TEXT PRIMARY KEY, payload TEXT NOT NULL)')
+            if previous_web:
+                old_manifest = load_snapshot(db, 'old', previous_web)
+                if old_manifest['built_at'] != previous['snapshot_at']:
+                    raise ValueError('previous groups no longer match their feed snapshot')
+                if snapshot_digest(db, 'old') != previous['snapshot_sha256']:
+                    raise ValueError('previous snapshot content changed after publication')
+            manifest = load_snapshot(db, 'new', web)
+            if previous and manifest['built_at'] <= previous['snapshot_at']:
+                raise ValueError('snapshot must advance beyond the previous published snapshot')
+            pages, buffer, size = [], [], 0
+
+            def flush():
+                nonlocal buffer, size
+                if not buffer:
+                    return
+                data = b''.join(buffer)
+                name = f'{len(pages):06d}.ndjson'
+                (scratch / name).write_bytes(data)
+                pages.append({'file': name, 'rows': len(buffer), 'bytes': len(data), 'sha256': digest(data)})
+                buffer, size = [], 0
+
+            counts = {'upsert': 0, 'remove': 0}
+            queries = (
+                ('upsert', 'SELECT n.key,n.payload FROM new n LEFT JOIN old o ON o.key=n.key '
+                 'WHERE o.key IS NULL OR n.payload != o.payload ORDER BY n.key'),
+                ('remove', 'SELECT o.key,NULL FROM old o LEFT JOIN new n ON n.key=o.key '
+                 'WHERE n.key IS NULL ORDER BY o.key'),
+            )
+            for op, query in queries:
+                for key, payload in db.execute(query):
+                    row = {'op': op, 'key': key}
+                    if payload is not None:
+                        row['job'] = json.loads(payload)
+                    line = encode(row) + b'\n'
+                    if len(line) > MAX_BYTES:
+                        raise ValueError(f'job exceeds page byte limit: {key}')
+                    if len(buffer) >= MAX_ROWS or size + len(line) > MAX_BYTES:
+                        flush()
+                    buffer.append(line)
+                    size += len(line)
+                    counts[op] += 1
+            flush()
+            snapshot_sha256 = snapshot_digest(db, 'new')
+        header = {'version': 1, 'snapshot_at': manifest['built_at'], 'jobs': manifest['jobs'],
+                  'snapshot_sha256': snapshot_sha256,
+                  'previous': previous['generation'] if previous else None,
+                  'counts': counts, 'pages': pages}
+        generation = digest(encode(header))
+        header['generation'] = generation
+        destination = web / 'changes' / generation
+        destination.mkdir(parents=True, exist_ok=True)
+        for page in pages:
+            shutil.copyfile(scratch / page['file'], destination / page['file'])
+        data = encode(header)
+        (destination / 'manifest.json').write_bytes(data)
+        # This is a local candidate, not evidence of publication. Publish last remotely.
+        (web / 'changes/latest.json').write_bytes(data)
+        return header
+
+
+def remote_head(base):
+    # The unique query avoids intermediary caches of the mutable pointer.
+    url = base.rstrip('/') + '/data/changes/latest.json?check=' + uuid.uuid4().hex
+    try:
+        with urllib.request.urlopen(urllib.request.Request(url, headers={'Cache-Control': 'no-cache'}),
+                                    timeout=60) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return None
+        raise
+
+
+def put(key, path):
+    command = 'npx.cmd' if os.name == 'nt' else 'npx'
+    subprocess.run([command, 'wrangler', 'r2', 'object', 'put', f'jobscream-data/{key}',
+                    '--file', str(path), '--content-type',
+                    'application/x-ndjson' if key.endswith('.ndjson') else 'application/json',
+                    '--remote'], check=True)
+
+
+def publish(web, header, base, get_head=remote_head, upload=put):
+    """Single publisher only. Reject a stale parent; never advance head after an upload failure."""
+    head = get_head(base)
+    actual = head['generation'] if head else None
+    if actual not in (header['previous'], header['generation']):
+        raise ValueError('remote head differs from previous snapshot; recover the last published export')
+    folder = Path(web) / 'changes' / header['generation']
+    for page in header['pages']:
+        data = (folder / page['file']).read_bytes()
+        if len(data) != page['bytes'] or digest(data) != page['sha256']:
+            raise ValueError('page changed after build')
+        upload(f"changes/{header['generation']}/{page['file']}", folder / page['file'])
+    upload(f"changes/{header['generation']}/manifest.json", folder / 'manifest.json')
+    # Detect an unexpected competing run before changing the pointer; not a distributed lock.
+    if get_head(base) != head:
+        raise ValueError('remote head changed during upload; serialize publishers and retry')
+    upload('changes/latest.json', folder / 'manifest.json')
+    if get_head(base) != header:
+        raise ValueError('publication readback did not match; retain this export and inspect before retrying')
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--web', type=Path, required=True)
+    parser.add_argument('--previous-web', type=Path)
+    parser.add_argument('--publish-base', help='opt in to R2 publication; URL of the Worker serving that bucket')
+    args = parser.parse_args()
+    header = build(args.web, args.previous_web)
+    if args.publish_base:
+        publish(args.web, header, args.publish_base)
+    print(json.dumps({'generation': header['generation'], 'counts': header['counts'],
+                      'pages': len(header['pages']), 'published': bool(args.publish_base)}))
+
+
+if __name__ == '__main__':
+    main()

--- a/backend/scripts/build-job-changes.py
+++ b/backend/scripts/build-job-changes.py
@@ -1,11 +1,18 @@
 #!/usr/bin/env python3
-"""Build/publish a public snapshot change feed. Standard library only; see JOB-CHANGES.md."""
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["duckdb>=1.1"]
+# ///
+"""Project verified crawler diffs into an immutable, paged feed; see JOB-CHANGES.md."""
 import argparse
+from collections import Counter
 from contextlib import closing
+from datetime import date, datetime, timezone
 import hashlib
 import json
 import os
 from pathlib import Path
+import re
 import shutil
 import sqlite3
 import subprocess
@@ -14,7 +21,12 @@ import urllib.error
 import urllib.request
 import uuid
 
-FIELDS = ('ats', 'slug', 'id', 'title', 'company', 'location', 'url', 'seen', 'pub', 'jd')
+VERSION = 2
+SCOPE = 'crawler-export-v1'
+FIRST_DATE = '2026-09-08'
+FIELDS = ('ats', 'slug', 'id', 'title', 'location', 'url', 'content',
+          'embed_status', 'published_at', 'first_seen_at')
+CHANGE_KEY = {'title', 'location', 'url', 'content', 'embed_status', 'published_at'}
 MAX_ROWS = 1000
 MAX_BYTES = 4 * 1024 * 1024
 
@@ -32,120 +44,321 @@ def read_json(path):
     return json.loads(Path(path).read_text(encoding='utf-8'))
 
 
-def load_snapshot(db, table, web):
-    """One group in memory at a time; stale, unreferenced group files are ignored."""
-    manifest = read_json(web / 'manifest.json')
-    leaves = [n for n in manifest['tree'] if not n['children']]
-    ids = [n['id'] for n in leaves]
-    if (any(type(i) is not int or i < 0 for i in ids) or len(set(ids)) != len(ids)
-            or len(ids) != manifest['leaves'] or not ids):
-        raise ValueError('invalid or empty manifest leaves')
-    count = 0
-    for leaf in leaves:
-        group = read_json(web / 'groups' / f"{leaf['id']}.json")
-        if group['leaf'] != leaf['id'] or len(group['jobs']) != leaf['size']:
-            raise ValueError('incomplete or mismatched group')
-        for job in group['jobs']:
-            if any(not isinstance(job.get(k), str) or not job[k] for k in ('ats', 'slug', 'id')):
-                raise ValueError('invalid job identity')
-            key = f"{job['ats']}/{job['slug']}#{job['id']}"
-            payload = encode({k: job[k] for k in FIELDS if k in job}).decode('utf-8')
-            # Duplicate identities fail closed rather than emitting ambiguous removals/updates.
-            db.execute(f'INSERT INTO {table} VALUES (?, ?)', (key, payload))
-            count += 1
-    if count != manifest['jobs'] or count != sum(n['size'] for n in leaves):
-        raise ValueError('incomplete snapshot job count')
-    db.commit()
-    return manifest
+def sha256_file(path):
+    h = hashlib.sha256()
+    with Path(path).open('rb') as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b''):
+            h.update(chunk)
+    return h.hexdigest()
 
 
-def snapshot_digest(db, table):
-    checksum = hashlib.sha256()
-    for key, payload in db.execute(f'SELECT key,payload FROM {table} ORDER BY key'):
-        checksum.update(encode([key, payload]) + b'\n')
-    return checksum.hexdigest()
+def require_hash(value):
+    if not isinstance(value, str) or not re.fullmatch('[0-9a-f]{64}', value):
+        raise ValueError('invalid sha256')
+    return value
 
 
-def build(web, previous_web=None):
-    web = Path(web).resolve()
-    previous_web = Path(previous_web).resolve() if previous_web else None
-    if web == previous_web:
-        raise ValueError('previous snapshot must be a separate preserved directory')
-    previous = read_json(previous_web / 'changes/latest.json') if previous_web else None
-    if previous and previous.get('version') != 1:
-        raise ValueError('unsupported previous feed version')
-    with tempfile.TemporaryDirectory(prefix='job-changes-') as scratch:
-        scratch = Path(scratch)
-        with closing(sqlite3.connect(scratch / 'jobs.sqlite')) as db:
-            for table in ('old', 'new'):
-                db.execute(f'CREATE TABLE {table} (key TEXT PRIMARY KEY, payload TEXT NOT NULL)')
-            if previous_web:
-                old_manifest = load_snapshot(db, 'old', previous_web)
-                if old_manifest['built_at'] != previous['snapshot_at']:
-                    raise ValueError('previous groups no longer match their feed snapshot')
-                if snapshot_digest(db, 'old') != previous['snapshot_sha256']:
-                    raise ValueError('previous snapshot content changed after publication')
-            manifest = load_snapshot(db, 'new', web)
-            if previous and manifest['built_at'] <= previous['snapshot_at']:
-                raise ValueError('snapshot must advance beyond the previous published snapshot')
-            pages, buffer, size = [], [], 0
+def require_date(value):
+    if not isinstance(value, str) or date.fromisoformat(value).isoformat() != value:
+        raise ValueError('invalid export date')
+    return value
 
-            def flush():
-                nonlocal buffer, size
-                if not buffer:
-                    return
-                data = b''.join(buffer)
-                name = f'{len(pages):06d}.ndjson'
-                (scratch / name).write_bytes(data)
-                pages.append({'file': name, 'rows': len(buffer), 'bytes': len(data), 'sha256': digest(data)})
-                buffer, size = [], 0
 
-            counts = {'upsert': 0, 'remove': 0}
-            queries = (
-                ('upsert', 'SELECT n.key,n.payload FROM new n LEFT JOIN old o ON o.key=n.key '
-                 'WHERE o.key IS NULL OR n.payload != o.payload ORDER BY n.key'),
-                ('remove', 'SELECT o.key,NULL FROM old o LEFT JOIN new n ON n.key=o.key '
-                 'WHERE n.key IS NULL ORDER BY o.key'),
-            )
-            for op, query in queries:
-                for key, payload in db.execute(query):
-                    row = {'op': op, 'key': key}
-                    if payload is not None:
-                        row['job'] = json.loads(payload)
-                    line = encode(row) + b'\n'
-                    if len(line) > MAX_BYTES:
-                        raise ValueError(f'job exceeds page byte limit: {key}')
-                    if len(buffer) >= MAX_ROWS or size + len(line) > MAX_BYTES:
-                        flush()
-                    buffer.append(line)
-                    size += len(line)
-                    counts[op] += 1
+def part_paths(folder, parts, suffix):
+    names = set()
+    for part in parts:
+        name = part['file']
+        if (not isinstance(name, str) or not re.fullmatch(r'[A-Za-z0-9_-]+\.' + suffix, name)
+                or name in names):
+            raise ValueError('invalid or duplicate part name')
+        names.add(name)
+        require_hash(part['sha256'])
+        path = Path(folder) / name
+        if type(part['bytes']) is not int or part['bytes'] < 0:
+            raise ValueError('invalid part size')
+        if path.stat().st_size != part['bytes'] or sha256_file(path) != part['sha256']:
+            raise ValueError('part checksum/size mismatch')
+        yield path
+
+
+def validate_header(header):
+    if header.get('version') != VERSION or header.get('scope') != SCOPE:
+        raise ValueError('unsupported feed version/scope; bootstrap v2')
+    claimed = require_hash(header['generation'])
+    if digest(encode({k: v for k, v in header.items() if k != 'generation'})) != claimed:
+        raise ValueError('manifest checksum mismatch')
+    if header['previous'] is not None:
+        require_hash(header['previous'])
+    if header['kind'] not in ('bootstrap', 'delta'):
+        raise ValueError('invalid generation kind')
+    require_date(header['cursor'])
+    return header
+
+
+def parquet_rows(paths, columns):
+    # DuckDB reads only the allowlisted columns (no vectors/raw JSON). No corpus-sized Python list.
+    import duckdb
+    with closing(duckdb.connect()) as con:
+        con.execute("SET memory_limit='512MB'")
+        for path in paths:
+            # Return UTC-naive datetime values so DuckDB does not require optional pytz.
+            expressions = [(f'"{c}" AT TIME ZONE \'UTC\'' if c in
+                            ('published_at', 'first_seen_at', 'removed_at_crawler') else f'"{c}"')
+                           for c in columns]
+            cursor = con.execute('SELECT ' + ','.join(expressions)
+                                 + ' FROM read_parquet(?)', [str(path)])
+            while batch := cursor.fetchmany(128):
+                for values in batch:
+                    yield dict(zip(columns, values))
+
+
+def timestamp(value):
+    if value is None:
+        return None
+    if not isinstance(value, datetime):
+        raise ValueError('expected parquet timestamp')
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)  # normalized by parquet_rows
+    return value.astimezone(timezone.utc).isoformat().replace('+00:00', 'Z')
+
+
+def identity(row):
+    if any(not isinstance(row.get(k), str) or not row[k] for k in ('ats', 'slug', 'id')):
+        raise ValueError('invalid job identity')
+    return f"{row['ats']}/{row['slug']}#{row['id']}"
+
+
+def event(row, op):
+    key = identity(row)
+    if op == 'remove':
+        reason = row['removal']
+        if reason not in ('closed', 'left_dataset', 'unknown'):
+            raise ValueError('invalid removal reason')
+        return {'op': op, 'key': key, 'removal': reason,
+                'removed_at_crawler': timestamp(row['removed_at_crawler'])}
+    if row['is_open'] is not True:
+        raise ValueError('bootstrap/upsert must come from an open-job export')
+    job = {k: row[k] for k in FIELDS}
+    # The upstream change key hashes coalesce(content, ''); mirror that equivalence.
+    job['content'] = job['content'] or ''
+    for k in ('published_at', 'first_seen_at'):
+        job[k] = timestamp(job[k])
+    return {'op': op, 'key': key, 'job': job}
+
+
+def source_ref(side):
+    return {'diff': side['from'] + '__' + side['to'],
+            'content_sha256': require_hash(side['content_sha256'])}
+
+
+def check_sidecar(side):
+    if side.get('schema_version') != 2 or side.get('carry_done') is not True:
+        raise ValueError('diff is not a completed v2 diff')
+    if require_date(side['from']) >= require_date(side['to']):
+        raise ValueError('diff dates must advance')
+    if not CHANGE_KEY.issubset(side['change_key']):
+        raise ValueError('diff does not track all projected mutable fields')
+    full = side['parts']
+    names = [p['file'] for p in full]
+    if not full or len(names) != len(set(names)):
+        raise ValueError('missing/duplicate full part descriptors')
+    combined = '\n'.join(f"{p['file']} {require_hash(p['sha256'])}"
+                         for p in sorted(full, key=lambda p: p['file']))
+    if digest(combined.encode()) != side['content_sha256']:
+        raise ValueError('source content digest mismatch')
+    if not side['lite']['parts']:
+        raise ValueError('missing lite parts')
+    for op in ('added', 'changed', 'removed', 'carried'):
+        if type(side['counts'][op]) is not int or side['counts'][op] < 0:
+            raise ValueError('invalid source event count')
+
+
+def store_event(db, row):
+    try:
+        db.execute('INSERT INTO events VALUES (?, ?)', (row['key'], encode(row).decode()))
+    except sqlite3.IntegrityError as exc:
+        raise ValueError('duplicate or conflicting job events') from exc
+
+
+def load_delta(db, path, previous):
+    side = read_json(path)
+    check_sidecar(side)
+    if side['from'] != previous['cursor'] or side['parent'] != previous['source']:
+        raise ValueError('source gap or parent mismatch; re-bootstrap, never skip')
+    folder = Path(path).with_suffix('') / 'lite'
+    paths = list(part_paths(folder, side['lite']['parts'], 'parquet'))
+    counts = Counter()
+    columns = FIELDS + ('op', 'from_date', 'to_date', 'is_open', 'removal', 'removed_at_crawler')
+    for row in parquet_rows(paths, columns):
+        op = row['op']
+        if op not in ('added', 'changed', 'removed', 'changed_prev', 'carried'):
+            raise ValueError('unknown source operation')
+        if row['from_date'] != side['from'] or row['to_date'] != side['to']:
+            raise ValueError('row date differs from sidecar')
+        key = identity(row)
+        try:
+            db.execute('INSERT INTO source_rows VALUES (?, ?)', (key, op))
+        except sqlite3.IntegrityError as exc:
+            raise ValueError('duplicate source operation') from exc
+        counts[op] += 1
+        if op in ('added', 'changed', 'removed'):
+            store_event(db, event(row, 'remove' if op == 'removed' else 'upsert'))
+    expected = dict(side['counts'], changed_prev=side['counts']['changed'])
+    if any(counts[op] != expected[op] for op in expected):
+        raise ValueError('incomplete source event counts')
+    # Counts alone cannot establish that the previous and current versions refer to the same keys.
+    if db.execute("SELECT key FROM source_rows GROUP BY key HAVING "
+                  "(count(*) > 1 AND NOT (count(*) = 2 AND min(op) = 'changed' "
+                  "AND max(op) = 'changed_prev')) OR "
+                  "(count(*) = 1 AND min(op) IN ('changed','changed_prev')) LIMIT 1").fetchone():
+        raise ValueError('conflicting source events or unpaired change')
+    # Detect inputs changed during parsing, before producing any candidate head.
+    list(part_paths(folder, side['lite']['parts'], 'parquet'))
+    if read_json(path) != side:
+        raise ValueError('sidecar changed during build')
+    return {'cursor': side['to'], 'source': source_ref(side), 'source_sha256': digest(encode(side)),
+            'kind': 'delta', 'snapshot_at': None}
+
+
+def load_bootstrap(db, snapshot, index_path):
+    snapshot = Path(snapshot).resolve()
+    index = read_json(index_path)
+    cursor = require_date(snapshot.name)
+    if cursor < FIRST_DATE or index.get('head') != cursor:
+        raise ValueError('bootstrap must match index head and be September 8 or later')
+    manifest = read_json(snapshot / 'web/manifest.json')
+    if not index.get('snapshot_built_at') or manifest['built_at'] != index['snapshot_built_at']:
+        raise ValueError('bootstrap snapshot/index mismatch')
+    anchors = [e for e in index['entries'] if e['to'] == cursor]
+    if len(anchors) != 1:
+        raise ValueError('bootstrap requires one published diff anchor at index head')
+    anchor = anchors[0]
+    source = source_ref(anchor)
+    paths = sorted((snapshot / 'jobs').glob('*.parquet'))
+    if not paths:
+        raise ValueError('missing bootstrap parquet')
+    hashes = [(p.name, sha256_file(p)) for p in paths]
+    for row in parquet_rows(paths, FIELDS + ('is_open',)):
+        store_event(db, event(row, 'upsert'))
+    if db.execute('SELECT count(*) FROM events').fetchone()[0] != anchor['new_jobs_after_carry']:
+        raise ValueError('incomplete bootstrap export count')
+    if (sorted((snapshot / 'jobs').glob('*.parquet')) != paths
+            or hashes != [(p.name, sha256_file(p)) for p in paths]
+            or read_json(index_path) != index
+            or read_json(snapshot / 'web/manifest.json') != manifest):
+        raise ValueError('bootstrap inputs changed during build')
+    return {'cursor': cursor, 'source': source, 'kind': 'bootstrap',
+            'snapshot_at': manifest['built_at'], 'source_sha256': digest(encode(hashes))}
+
+
+def write_generation(out, db, metadata, previous, scratch):
+    pages, buffer, size = [], [], 0
+    counts = {'upsert': 0, 'remove': 0}
+
+    def flush():
+        nonlocal buffer, size
+        if buffer:
+            data = b''.join(buffer)
+            name = f'{len(pages):06d}.ndjson'
+            (scratch / name).write_bytes(data)
+            pages.append({'file': name, 'rows': len(buffer), 'bytes': len(data), 'sha256': digest(data)})
+            buffer, size = [], 0
+
+    for (payload,) in db.execute('SELECT payload FROM events ORDER BY key'):
+        line = payload.encode('utf-8') + b'\n'
+        if len(line) > MAX_BYTES:
+            raise ValueError('job exceeds page byte limit')
+        if len(buffer) >= MAX_ROWS or size + len(line) > MAX_BYTES:
             flush()
-            snapshot_sha256 = snapshot_digest(db, 'new')
-        header = {'version': 1, 'snapshot_at': manifest['built_at'], 'jobs': manifest['jobs'],
-                  'snapshot_sha256': snapshot_sha256,
-                  'previous': previous['generation'] if previous else None,
-                  'counts': counts, 'pages': pages}
-        generation = digest(encode(header))
-        header['generation'] = generation
-        destination = web / 'changes' / generation
-        destination.mkdir(parents=True, exist_ok=True)
-        for page in pages:
-            shutil.copyfile(scratch / page['file'], destination / page['file'])
-        data = encode(header)
-        (destination / 'manifest.json').write_bytes(data)
-        # This is a local candidate, not evidence of publication. Publish last remotely.
-        (web / 'changes/latest.json').write_bytes(data)
-        return header
+        buffer.append(line)
+        size += len(line)
+        counts[json.loads(payload)['op']] += 1
+    flush()
+    header = dict(metadata, version=VERSION, scope=SCOPE,
+                  previous=previous['generation'] if previous else None, counts=counts, pages=pages)
+    header['generation'] = digest(encode(header))
+    destination = Path(out) / 'changes' / header['generation']
+    destination.mkdir(parents=True, exist_ok=True)
+    for page in pages:
+        shutil.copyfile(scratch / page['file'], destination / page['file'])
+    data = encode(header)
+    (destination / 'manifest.json').write_bytes(data)
+    # A candidate only: the last successfully published header must be retained separately.
+    temporary = Path(out) / 'changes/latest.json.tmp'
+    temporary.write_bytes(data)
+    temporary.replace(Path(out) / 'changes/latest.json')
+    return header
+
+
+def build(out, *, diff=None, previous=None, snapshot=None, index=None):
+    if bool(diff) == bool(snapshot) or (snapshot and not index) or (diff and not previous):
+        raise ValueError('choose a diff with previous header, or snapshot with index')
+    if previous:
+        validate_header(previous)
+    with tempfile.TemporaryDirectory(prefix='job-changes-') as tmp:
+        scratch = Path(tmp)
+        with closing(sqlite3.connect(scratch / 'events.sqlite')) as db:
+            db.execute('CREATE TABLE events (key TEXT PRIMARY KEY, payload TEXT NOT NULL)')
+            db.execute('CREATE TABLE source_rows (key TEXT, op TEXT, PRIMARY KEY(key,op))')
+            metadata = load_delta(db, diff, previous) if diff else load_bootstrap(db, snapshot, index)
+            if previous and metadata['cursor'] < previous['cursor']:
+                raise ValueError('cannot move cursor backwards')
+            if previous and metadata['cursor'] == previous['cursor'] and metadata['source'] != previous['source']:
+                raise ValueError('same-date source was rewritten')
+            return write_generation(out, db, metadata, previous, scratch)
+
+
+def verified_rows(folder, header):
+    validate_header(header)
+    counts = Counter()
+    for part, path in zip(header['pages'], part_paths(folder, header['pages'], 'ndjson')):
+        if not 0 < part['rows'] <= MAX_ROWS or part['bytes'] > MAX_BYTES:
+            raise ValueError('page exceeds bounds')
+        lines = path.read_bytes().splitlines()
+        if len(lines) != part['rows']:
+            raise ValueError('page row count mismatch')
+        for line in lines:
+            row = json.loads(line)
+            if row['op'] not in ('upsert', 'remove'):
+                raise ValueError('invalid feed operation')
+            if row['op'] == 'upsert' and row['key'] != identity(row['job']):
+                raise ValueError('event key mismatch')
+            counts[row['op']] += 1
+            yield row
+    if {op: counts[op] for op in ('upsert', 'remove')} != header['counts']:
+        raise ValueError('generation count mismatch')
+
+
+def apply_generation(db, folder, header, *, reset=False):
+    """Reference transactional consumer; never commit a partial generation or skip a gap."""
+    validate_header(header)
+    db.execute('CREATE TABLE IF NOT EXISTS jobs (key TEXT PRIMARY KEY, payload TEXT NOT NULL)')
+    db.execute('CREATE TABLE IF NOT EXISTS checkpoint (singleton INTEGER PRIMARY KEY CHECK(singleton=1), generation TEXT)')
+    current = db.execute('SELECT generation FROM checkpoint WHERE singleton=1').fetchone()
+    current = current[0] if current else None
+    if current == header['generation']:
+        return
+    if header['kind'] == 'bootstrap':
+        if current is not None and not reset:
+            raise ValueError('bootstrap replaces state; explicit reset required')
+    elif current is None or current != header['previous']:
+        raise ValueError('consumer gap; re-bootstrap, never skip')
+    with db:
+        if header['kind'] == 'bootstrap':
+            db.execute('DELETE FROM jobs')
+        for row in verified_rows(folder, header):
+            if row['op'] == 'upsert':
+                db.execute('INSERT OR REPLACE INTO jobs VALUES (?,?)', (row['key'], encode(row['job']).decode()))
+            else:
+                db.execute('DELETE FROM jobs WHERE key=?', (row['key'],))
+        db.execute('INSERT OR REPLACE INTO checkpoint VALUES (1,?)', (header['generation'],))
 
 
 def remote_head(base):
-    # The unique query avoids intermediary caches of the mutable pointer.
     url = base.rstrip('/') + '/data/changes/latest.json?check=' + uuid.uuid4().hex
     try:
-        with urllib.request.urlopen(urllib.request.Request(url, headers={'Cache-Control': 'no-cache'}),
-                                    timeout=60) as response:
-            return json.load(response)
+        with urllib.request.urlopen(urllib.request.Request(url, headers={'Cache-Control': 'no-cache'}), timeout=60) as r:
+            return json.load(r)
     except urllib.error.HTTPError as error:
         if error.code == 404:
             return None
@@ -160,38 +373,52 @@ def put(key, path):
                     '--remote'], check=True)
 
 
-def publish(web, header, base, get_head=remote_head, upload=put):
-    """Single publisher only. Reject a stale parent; never advance head after an upload failure."""
+def publish(out, header, base, get_head=remote_head, upload=put):
+    validate_header(header)
     head = get_head(base)
+    if head:
+        validate_header(head)
     actual = head['generation'] if head else None
     if actual not in (header['previous'], header['generation']):
-        raise ValueError('remote head differs from previous snapshot; recover the last published export')
-    folder = Path(web) / 'changes' / header['generation']
+        raise ValueError('remote head differs from previous generation')
+    folder = Path(out) / 'changes' / header['generation']
+    if read_json(folder / 'manifest.json') != header:
+        raise ValueError('local manifest changed after build')
+    # Validate the whole generation before any upload; an invalid later page cannot leave a new head.
+    for _ in verified_rows(folder, header):
+        pass
     for page in header['pages']:
-        data = (folder / page['file']).read_bytes()
-        if len(data) != page['bytes'] or digest(data) != page['sha256']:
-            raise ValueError('page changed after build')
         upload(f"changes/{header['generation']}/{page['file']}", folder / page['file'])
     upload(f"changes/{header['generation']}/manifest.json", folder / 'manifest.json')
-    # Detect an unexpected competing run before changing the pointer; not a distributed lock.
     if get_head(base) != head:
-        raise ValueError('remote head changed during upload; serialize publishers and retry')
+        raise ValueError('remote head changed during upload; serialize publishers')
     upload('changes/latest.json', folder / 'manifest.json')
     if get_head(base) != header:
-        raise ValueError('publication readback did not match; retain this export and inspect before retrying')
+        raise ValueError('publication readback mismatch; retry the same candidate')
 
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--web', type=Path, required=True)
-    parser.add_argument('--previous-web', type=Path)
-    parser.add_argument('--publish-base', help='opt in to R2 publication; URL of the Worker serving that bucket')
+    parser.add_argument('--out', type=Path, required=True)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--diff', type=Path, help='completed v2 diff sidecar, adjacent to its lite directory')
+    group.add_argument('--snapshot', type=Path, help='completed export/YYYY-MM-DD for bootstrap/recovery')
+    group.add_argument('--candidate', type=Path, help='retry a built manifest without rereading source exports')
+    parser.add_argument('--index', type=Path, help='saved diffs/index.json matching the bootstrap export')
+    parser.add_argument('--previous', type=Path, help='last successfully published feed manifest (not candidate latest)')
+    parser.add_argument('--publish-base', help='opt in to R2 publication via the existing Worker')
     args = parser.parse_args()
-    header = build(args.web, args.previous_web)
+    header = (validate_header(read_json(args.candidate)) if args.candidate else
+              build(args.out, diff=args.diff, previous=read_json(args.previous) if args.previous else None,
+                    snapshot=args.snapshot, index=args.index))
     if args.publish_base:
-        publish(args.web, header, args.publish_base)
-    print(json.dumps({'generation': header['generation'], 'counts': header['counts'],
-                      'pages': len(header['pages']), 'published': bool(args.publish_base)}))
+        publish(args.out, header, args.publish_base)
+        # A durable success receipt, separate from changes/latest.json (which is only a candidate).
+        receipt = args.out / 'published.json.tmp'
+        receipt.write_bytes(encode(header))
+        receipt.replace(args.out / 'published.json')
+    print(json.dumps({'generation': header['generation'], 'cursor': header['cursor'],
+                      'counts': header['counts'], 'published': bool(args.publish_base)}))
 
 
 if __name__ == '__main__':

--- a/backend/scripts/test_job_changes.py
+++ b/backend/scripts/test_job_changes.py
@@ -1,0 +1,111 @@
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+spec = importlib.util.spec_from_file_location('changes', Path(__file__).with_name('build-job-changes.py'))
+changes = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(changes)
+
+
+class ChangesTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+
+    def snapshot(self, name, jobs, timestamp, leaf=0):
+        web = self.root / name
+        (web / 'groups').mkdir(parents=True)
+        (web / 'manifest.json').write_text(json.dumps({'built_at': timestamp, 'jobs': len(jobs),
+            'leaves': 1, 'tree': [{'id': leaf, 'size': len(jobs), 'children': []}]}))
+        (web / 'groups' / f'{leaf}.json').write_text(json.dumps({'leaf': leaf, 'jobs': jobs}))
+        return web
+
+    def job(self, identity='1', **extra):
+        return dict(ats='example', slug='company', id=identity, title='Engineer',
+                    location='Phoenix, AZ', jd='Build things', seen=100, pub=100, **extra)
+
+    def rows(self, web, header):
+        return [json.loads(line) for page in header['pages']
+                for line in (web / 'changes' / header['generation'] / page['file']).read_text().splitlines()]
+
+    def test_bootstrap_delta_and_replay(self):
+        first = self.snapshot('first', [self.job(), self.job('2')], 1)
+        initial = changes.build(first)
+        updated = self.job(); updated['location'] = 'San Diego, CA'
+        second = self.snapshot('second', [updated, self.job('3')], 2, leaf=17)
+        delta = changes.build(second, first)
+        self.assertEqual(delta['previous'], initial['generation'])
+        self.assertEqual(delta['counts'], {'upsert': 2, 'remove': 1})
+        state = {}
+        for row in self.rows(first, initial) + self.rows(second, delta) * 2:
+            if row['op'] == 'remove': state.pop(row['key'], None)
+            else: state[row['key']] = row['job']
+        self.assertEqual(set(state), {'example/company#1', 'example/company#3'})
+        self.assertEqual(state['example/company#1']['location'], 'San Diego, CA')
+        self.assertEqual(changes.build(second, first), delta)
+
+    def test_reclustering_vectors_and_unknown_fields_do_not_emit_changes(self):
+        first = self.snapshot('first', [self.job(v='old', last_seen_ms=1)], 1)
+        changes.build(first)
+        second = self.snapshot('second', [self.job(v='new', last_seen_ms=2)], 2, leaf=99)
+        delta = changes.build(second, first)
+        self.assertEqual(delta['pages'], [])
+        self.assertEqual(delta['counts'], {'upsert': 0, 'remove': 0})
+
+    def test_incomplete_or_duplicate_input_fails(self):
+        web = self.snapshot('missing', [self.job()], 1)
+        (web / 'groups/0.json').unlink()
+        with self.assertRaises(FileNotFoundError): changes.build(web)
+        self.assertFalse((web / 'changes/latest.json').exists())
+        web = self.snapshot('duplicate', [self.job(), self.job()], 1)
+        with self.assertRaises(changes.sqlite3.IntegrityError): changes.build(web)
+
+    def test_previous_content_must_match_published_digest(self):
+        first = self.snapshot('first', [self.job()], 1)
+        changes.build(first)
+        (first / 'groups/0.json').write_text(json.dumps({'leaf': 0, 'jobs': [self.job('changed')]}))
+        second = self.snapshot('second', [self.job()], 2)
+        with self.assertRaisesRegex(ValueError, 'content changed'): changes.build(second, first)
+
+    def test_page_bounds_and_oversized_record(self):
+        web = self.snapshot('many', [self.job(str(i)) for i in range(1001)], 1)
+        header = changes.build(web)
+        self.assertEqual([p['rows'] for p in header['pages']], [1000, 1])
+        job = self.job(); job['jd'] = 'x' * changes.MAX_BYTES
+        web = self.snapshot('large', [job], 2)
+        with self.assertRaisesRegex(ValueError, 'byte limit'): changes.build(web)
+
+    def test_publication_failure_never_advances_head_and_retry_succeeds(self):
+        web = self.snapshot('first', [self.job()], 1)
+        header = changes.build(web)
+        writes, remote = [], [None]
+        def fail(key, path):
+            writes.append(key)
+            raise RuntimeError('upload failed')
+        with self.assertRaises(RuntimeError):
+            changes.publish(web, header, 'https://example.test', lambda _: remote[0], fail)
+        self.assertNotIn('changes/latest.json', writes)
+        def upload(key, path):
+            writes.append(key)
+            if key == 'changes/latest.json': remote[0] = changes.read_json(path)
+        changes.publish(web, header, 'https://example.test', lambda _: remote[0], upload)
+        self.assertEqual(writes[-1], 'changes/latest.json')
+        self.assertEqual(remote[0], header)
+        changes.publish(web, header, 'https://example.test', lambda _: remote[0], upload)
+
+    def test_stale_parent_and_page_corruption_fail_closed(self):
+        web = self.snapshot('first', [self.job()], 1)
+        header = changes.build(web)
+        def forbidden(*args): self.fail('must not upload')
+        with self.assertRaisesRegex(ValueError, 'remote head differs'):
+            changes.publish(web, header, '', lambda _: {'generation': 'another'}, forbidden)
+        (web / 'changes' / header['generation'] / header['pages'][0]['file']).write_text('corrupt')
+        with self.assertRaisesRegex(ValueError, 'page changed'):
+            changes.publish(web, header, '', lambda _: None, forbidden)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/scripts/test_job_changes.py
+++ b/backend/scripts/test_job_changes.py
@@ -1,12 +1,24 @@
+"""Synthetic parquet integration fixtures; no network or production uploads."""
+import copy
+from datetime import datetime, timezone
 import importlib.util
-import json
 from pathlib import Path
+import sqlite3
+import subprocess
+import sys
 import tempfile
 import unittest
+from unittest.mock import patch
+import duckdb
 
 spec = importlib.util.spec_from_file_location('changes', Path(__file__).with_name('build-job-changes.py'))
 changes = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(changes)
+SCHEMA = dict(ats='VARCHAR', slug='VARCHAR', id='VARCHAR', title='VARCHAR', location='VARCHAR',
+              url='VARCHAR', content='VARCHAR', embed_status='VARCHAR', published_at='TIMESTAMPTZ',
+              first_seen_at='TIMESTAMPTZ', is_open='BOOLEAN', op='VARCHAR', from_date='VARCHAR',
+              to_date='VARCHAR', removal='VARCHAR', removed_at_crawler='TIMESTAMPTZ')
+NOW = datetime(2026, 9, 8, tzinfo=timezone.utc)
 
 
 class ChangesTest(unittest.TestCase):
@@ -14,97 +26,275 @@ class ChangesTest(unittest.TestCase):
         self.temp = tempfile.TemporaryDirectory()
         self.addCleanup(self.temp.cleanup)
         self.root = Path(self.temp.name)
-
-    def snapshot(self, name, jobs, timestamp, leaf=0):
-        web = self.root / name
-        (web / 'groups').mkdir(parents=True)
-        (web / 'manifest.json').write_text(json.dumps({'built_at': timestamp, 'jobs': len(jobs),
-            'leaves': 1, 'tree': [{'id': leaf, 'size': len(jobs), 'children': []}]}))
-        (web / 'groups' / f'{leaf}.json').write_text(json.dumps({'leaf': leaf, 'jobs': jobs}))
-        return web
+        self.out = self.root / 'feed'
+        self.anchor = {'diff': '2026-09-07__2026-09-08', 'content_sha256': 'a' * 64}
 
     def job(self, identity='1', **extra):
-        return dict(ats='example', slug='company', id=identity, title='Engineer',
-                    location='Phoenix, AZ', jd='Build things', seen=100, pub=100, **extra)
+        return dict(dict(ats='example', slug='company', id=identity, title='Engineer',
+                    location='Phoenix, AZ', url='https://example.test/job/' + identity,
+                    content='Build things', embed_status='done', published_at=NOW,
+                    first_seen_at=NOW, is_open=True, removal=None, removed_at_crawler=None), **extra)
 
-    def rows(self, web, header):
-        return [json.loads(line) for page in header['pages']
-                for line in (web / 'changes' / header['generation'] / page['file']).read_text().splitlines()]
+    def parquet(self, path, rows, schema=None):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        schema = schema or SCHEMA
+        with duckdb.connect() as con:
+            con.execute('CREATE TABLE jobs (' + ','.join(f'"{k}" {v}' for k, v in schema.items()) + ')')
+            if rows:
+                con.executemany('INSERT INTO jobs VALUES (' + ','.join('?' for _ in schema) + ')',
+                                [[row.get(k) for k in schema] for row in rows])
+            con.execute('COPY jobs TO ? (FORMAT PARQUET)', [str(path)])
 
-    def test_bootstrap_delta_and_replay(self):
-        first = self.snapshot('first', [self.job(), self.job('2')], 1)
-        initial = changes.build(first)
-        updated = self.job(); updated['location'] = 'San Diego, CA'
-        second = self.snapshot('second', [updated, self.job('3')], 2, leaf=17)
-        delta = changes.build(second, first)
-        self.assertEqual(delta['previous'], initial['generation'])
+    def bootstrap(self, rows=None, day='2026-09-08', previous=None):
+        rows = rows if rows is not None else [self.job()]
+        folder = self.root / day
+        (folder / 'web').mkdir(parents=True, exist_ok=True)
+        self.parquet(folder / 'jobs/example.parquet', rows)
+        (folder / 'web/manifest.json').write_bytes(changes.encode({'built_at': 123}))
+        index = self.root / (day + '-index.json')
+        index.write_bytes(changes.encode({'head': day, 'snapshot_built_at': 123, 'entries': [
+            {'from': self.anchor['diff'].split('__')[0], 'to': day,
+             'content_sha256': self.anchor['content_sha256'], 'new_jobs_after_carry': len(rows)}]}))
+        return changes.build(self.out, snapshot=folder, index=index, previous=previous)
+
+    def diff(self, events, previous, day='2026-09-09'):
+        folder = self.root / 'diffs' / (previous['cursor'] + '__' + day)
+        rows = [dict(row, op=op, from_date=previous['cursor'], to_date=day) for op, row in events]
+        part = folder / 'lite/data_0.parquet'
+        self.parquet(part, rows)
+        full_hash = 'b' * 64
+        side = {'schema_version': 2, 'carry_done': True, 'from': previous['cursor'], 'to': day,
+                'parent': previous['source'], 'change_key': sorted(changes.CHANGE_KEY),
+                'counts': {op: sum(o == op for o, _ in events) for op in ('added', 'changed', 'removed', 'carried')},
+                'parts': [{'file': 'data_0.parquet', 'sha256': full_hash}],
+                'content_sha256': changes.digest(f'data_0.parquet {full_hash}'.encode()),
+                'lite': {'parts': [{'file': part.name, 'bytes': part.stat().st_size,
+                                    'sha256': changes.sha256_file(part)}]}}
+        path = folder.with_suffix('.json'); path.write_bytes(changes.encode(side))
+        return path
+
+    def folder(self, header):
+        return self.out / 'changes' / header['generation']
+
+    def rows(self, header):
+        return list(changes.verified_rows(self.folder(header), header))
+
+    def test_bootstrap_delta_replay_and_recovery(self):
+        initial = self.bootstrap([self.job(), self.job('2')])
+        side = self.diff([('changed', self.job(location='San Diego, CA')), ('changed_prev', self.job()),
+                          ('added', self.job('3')), ('removed', self.job('2', removal='closed'))], initial)
+        delta = changes.build(self.out, diff=side, previous=initial)
         self.assertEqual(delta['counts'], {'upsert': 2, 'remove': 1})
-        state = {}
-        for row in self.rows(first, initial) + self.rows(second, delta) * 2:
-            if row['op'] == 'remove': state.pop(row['key'], None)
-            else: state[row['key']] = row['job']
-        self.assertEqual(set(state), {'example/company#1', 'example/company#3'})
-        self.assertEqual(state['example/company#1']['location'], 'San Diego, CA')
-        self.assertEqual(changes.build(second, first), delta)
+        self.assertEqual(changes.build(self.out, diff=side, previous=initial), delta)
+        with sqlite3.connect(':memory:') as db:
+            for header in (initial, delta, delta):
+                changes.apply_generation(db, self.folder(header), header)
+            self.assertEqual(db.execute('SELECT key FROM jobs ORDER BY key').fetchall(),
+                             [('example/company#1',), ('example/company#3',)])
+            self.anchor = delta['source']
+            fresh = self.bootstrap([self.job('4')], day='2026-09-09', previous=delta)
+            with self.assertRaisesRegex(ValueError, 'explicit reset'):
+                changes.apply_generation(db, self.folder(fresh), fresh)
+            changes.apply_generation(db, self.folder(fresh), fresh, reset=True)
+            self.assertEqual(db.execute('SELECT key FROM jobs').fetchall(), [('example/company#4',)])
 
-    def test_reclustering_vectors_and_unknown_fields_do_not_emit_changes(self):
-        first = self.snapshot('first', [self.job(v='old', last_seen_ms=1)], 1)
-        changes.build(first)
-        second = self.snapshot('second', [self.job(v='new', last_seen_ms=2)], 2, leaf=99)
-        delta = changes.build(second, first)
+    def test_carried_and_changed_prev_emit_no_event(self):
+        initial = self.bootstrap()
+        side = self.diff([('carried', self.job()), ('changed_prev', self.job('2')),
+                          ('changed', self.job('2', embed_status='pending'))], initial)
+        delta = changes.build(self.out, diff=side, previous=initial)
+        self.assertEqual([r['key'] for r in self.rows(delta)], ['example/company#2'])
+        self.assertEqual(self.rows(delta)[0]['job']['embed_status'], 'pending')
+
+    def test_removal_reasons_and_embedding_transitions(self):
+        initial = self.bootstrap()
+        for reason in ('closed', 'left_dataset', 'unknown'):
+            with self.subTest(reason=reason):
+                side = self.diff([('removed', self.job(removal=reason, removed_at_crawler=NOW))], initial)
+                delta = changes.build(self.out, diff=side, previous=initial)
+                self.assertEqual(self.rows(delta)[0]['removal'], reason)
+        for status in ('pending', 'done', 'error'):
+            side = self.diff([('changed_prev', self.job()), ('changed', self.job(embed_status=status))], initial)
+            delta = changes.build(self.out, diff=side, previous=initial)
+            self.assertEqual(self.rows(delta)[0]['job']['embed_status'], status)
+
+    def test_projected_mutable_fields_and_explicit_exclusions(self):
+        initial = self.bootstrap()
+        updates = dict(title='Manager', location='Mesa, CO', url='https://example.test/new',
+                       content='New description', embed_status='pending',
+                       published_at=datetime(2026, 9, 9, tzinfo=timezone.utc))
+        side = self.diff([('changed_prev', self.job()), ('changed', self.job(**updates))], initial)
+        job = self.rows(changes.build(self.out, diff=side, previous=initial))[0]['job']
+        self.assertEqual(set(job), set(changes.FIELDS))
+        for field, value in updates.items():
+            self.assertEqual(job[field], changes.timestamp(value) if field == 'published_at' else value)
+        self.assertNotIn('company', job)
+        self.assertNotIn('last_seen_at', job)
+
+    def test_empty_delta_advances_checkpoint(self):
+        initial = self.bootstrap()
+        delta = changes.build(self.out, diff=self.diff([], initial), previous=initial)
         self.assertEqual(delta['pages'], [])
-        self.assertEqual(delta['counts'], {'upsert': 0, 'remove': 0})
+        with sqlite3.connect(':memory:') as db:
+            for header in (initial, delta): changes.apply_generation(db, self.folder(header), header)
+            self.assertEqual(db.execute('SELECT generation FROM checkpoint').fetchone()[0], delta['generation'])
 
-    def test_incomplete_or_duplicate_input_fails(self):
-        web = self.snapshot('missing', [self.job()], 1)
-        (web / 'groups/0.json').unlink()
-        with self.assertRaises(FileNotFoundError): changes.build(web)
-        self.assertFalse((web / 'changes/latest.json').exists())
-        web = self.snapshot('duplicate', [self.job(), self.job()], 1)
-        with self.assertRaises(changes.sqlite3.IntegrityError): changes.build(web)
+    def test_source_gap_parent_hash_and_incomplete_diff_fail(self):
+        initial = self.bootstrap()
+        for field, value, message in [('from', '2026-09-07', 'gap'), ('parent', None, 'gap'),
+                                      ('carry_done', False, 'completed'), ('change_key', [], 'track'),
+                                      ('content_sha256', '0' * 64, 'digest')]:
+            with self.subTest(field=field):
+                path = self.diff([], initial)
+                side = changes.read_json(path); side[field] = value
+                path.write_bytes(changes.encode(side))
+                with self.assertRaisesRegex(ValueError, message):
+                    changes.build(self.out, diff=path, previous=initial)
 
-    def test_previous_content_must_match_published_digest(self):
-        first = self.snapshot('first', [self.job()], 1)
-        changes.build(first)
-        (first / 'groups/0.json').write_text(json.dumps({'leaf': 0, 'jobs': [self.job('changed')]}))
-        second = self.snapshot('second', [self.job()], 2)
-        with self.assertRaisesRegex(ValueError, 'content changed'): changes.build(second, first)
+    def test_duplicate_conflicting_unpaired_and_incomplete_rows_fail(self):
+        initial = self.bootstrap()
+        for rows in [[('added', self.job()), ('added', self.job())],
+                     [('changed', self.job()), ('changed_prev', self.job('2'))],
+                     [('carried', self.job()), ('added', self.job())], [('changed', self.job())]]:
+            with self.subTest(rows=rows), self.assertRaises(ValueError):
+                changes.build(self.out, diff=self.diff(rows, initial), previous=initial)
+        side = self.diff([], initial)
+        data = changes.read_json(side); data['counts']['added'] = 1
+        side.write_bytes(changes.encode(data))
+        with self.assertRaisesRegex(ValueError, 'counts'):
+            changes.build(self.out, diff=side, previous=initial)
 
-    def test_page_bounds_and_oversized_record(self):
-        web = self.snapshot('many', [self.job(str(i)) for i in range(1001)], 1)
-        header = changes.build(web)
+    def test_corrupt_missing_and_unsafe_source_parts_fail(self):
+        initial = self.bootstrap()
+        path = self.diff([], initial)
+        part = path.with_suffix('') / 'lite/data_0.parquet'; part.write_bytes(b'corrupt')
+        with self.assertRaisesRegex(ValueError, 'checksum'):
+            changes.build(self.out, diff=path, previous=initial)
+        part.unlink()
+        with self.assertRaises(FileNotFoundError): changes.build(self.out, diff=path, previous=initial)
+        side = changes.read_json(path); side['lite']['parts'][0]['file'] = '../elsewhere.parquet'
+        path.write_bytes(changes.encode(side))
+        with self.assertRaisesRegex(ValueError, 'part name'): changes.build(self.out, diff=path, previous=initial)
+
+    def test_bootstrap_alignment_cutoff_counts_and_duplicates(self):
+        self.bootstrap()
+        folder = self.root / '2026-09-08'; path = self.root / '2026-09-08-index.json'
+        original = changes.read_json(path)
+        for field, value in [('head', '2026-09-09'), ('snapshot_built_at', 124)]:
+            path.write_bytes(changes.encode(dict(original, **{field: value})))
+            with self.assertRaises(ValueError): changes.build(self.out, snapshot=folder, index=path)
+        data = copy.deepcopy(original); data['entries'][0]['new_jobs_after_carry'] = 5
+        path.write_bytes(changes.encode(data))
+        with self.assertRaisesRegex(ValueError, 'count'): changes.build(self.out, snapshot=folder, index=path)
+        with self.assertRaisesRegex(ValueError, 'September 8'): self.bootstrap(day='2026-09-07')
+        with self.assertRaisesRegex(ValueError, 'duplicate'): self.bootstrap([self.job(), self.job()])
+
+    def test_page_bounds_and_oversize(self):
+        header = self.bootstrap([self.job(str(i)) for i in range(1001)])
         self.assertEqual([p['rows'] for p in header['pages']], [1000, 1])
-        job = self.job(); job['jd'] = 'x' * changes.MAX_BYTES
-        web = self.snapshot('large', [job], 2)
-        with self.assertRaisesRegex(ValueError, 'byte limit'): changes.build(web)
+        with self.assertRaisesRegex(ValueError, 'byte limit'):
+            self.bootstrap([self.job(content='x' * changes.MAX_BYTES)])
 
-    def test_publication_failure_never_advances_head_and_retry_succeeds(self):
-        web = self.snapshot('first', [self.job()], 1)
-        header = changes.build(web)
-        writes, remote = [], [None]
-        def fail(key, path):
-            writes.append(key)
-            raise RuntimeError('upload failed')
-        with self.assertRaises(RuntimeError):
-            changes.publish(web, header, 'https://example.test', lambda _: remote[0], fail)
-        self.assertNotIn('changes/latest.json', writes)
-        def upload(key, path):
-            writes.append(key)
-            if key == 'changes/latest.json': remote[0] = changes.read_json(path)
-        changes.publish(web, header, 'https://example.test', lambda _: remote[0], upload)
-        self.assertEqual(writes[-1], 'changes/latest.json')
-        self.assertEqual(remote[0], header)
-        changes.publish(web, header, 'https://example.test', lambda _: remote[0], upload)
+    def test_each_upload_failure_preserves_head_and_retry_succeeds(self):
+        header = self.bootstrap()
+        for fail_at in range(len(header['pages']) + 2):
+            remote, writes = [None], []
+            def upload(key, path):
+                if len(writes) == fail_at: raise RuntimeError('interrupted')
+                writes.append(key)
+                if key == 'changes/latest.json': remote[0] = changes.read_json(path)
+            with self.assertRaises(RuntimeError):
+                changes.publish(self.out, header, '', lambda _: remote[0], upload)
+            self.assertIsNone(remote[0])
+            def success(key, path):
+                if key == 'changes/latest.json': remote[0] = changes.read_json(path)
+            for _ in range(2): changes.publish(self.out, header, '', lambda _: remote[0], success)
+            self.assertEqual(remote[0], header)
 
-    def test_stale_parent_and_page_corruption_fail_closed(self):
-        web = self.snapshot('first', [self.job()], 1)
-        header = changes.build(web)
-        def forbidden(*args): self.fail('must not upload')
+    def test_stale_parent_competing_publisher_and_manifest_corruption(self):
+        header = self.bootstrap()
+        other = dict(header, cursor='2026-09-10'); other.pop('generation')
+        other['generation'] = changes.digest(changes.encode(other))
         with self.assertRaisesRegex(ValueError, 'remote head differs'):
-            changes.publish(web, header, '', lambda _: {'generation': 'another'}, forbidden)
-        (web / 'changes' / header['generation'] / header['pages'][0]['file']).write_text('corrupt')
-        with self.assertRaisesRegex(ValueError, 'page changed'):
-            changes.publish(web, header, '', lambda _: None, forbidden)
+            changes.publish(self.out, header, '', lambda _: other, lambda *a: self.fail('upload'))
+        heads = iter([None, other]); writes = []
+        with self.assertRaisesRegex(ValueError, 'changed during upload'):
+            changes.publish(self.out, header, '', lambda _: next(heads), lambda key, path: writes.append(key))
+        self.assertNotIn('changes/latest.json', writes)
+        (self.folder(header) / 'manifest.json').write_text('{}')
+        with self.assertRaisesRegex(ValueError, 'manifest changed'):
+            changes.publish(self.out, header, '', lambda _: None, lambda *a: self.fail('upload'))
+
+    def test_consumer_gap_and_corruption_roll_back_data_and_cursor(self):
+        initial = self.bootstrap()
+        with patch.object(changes, 'MAX_ROWS', 1):
+            delta = changes.build(self.out, diff=self.diff([('added', self.job('2')),
+                                    ('added', self.job('3'))], initial), previous=initial)
+        with sqlite3.connect(':memory:') as db:
+            with self.assertRaisesRegex(ValueError, 'gap'): changes.apply_generation(db, self.folder(delta), delta)
+            changes.apply_generation(db, self.folder(initial), initial)
+            (self.folder(delta) / delta['pages'][1]['file']).write_bytes(b'bad')
+            with self.assertRaisesRegex(ValueError, 'checksum'): changes.apply_generation(db, self.folder(delta), delta)
+            self.assertEqual(db.execute('SELECT key FROM jobs').fetchall(), [('example/company#1',)])
+            self.assertEqual(db.execute('SELECT generation FROM checkpoint').fetchone()[0], initial['generation'])
+
+    def test_final_readback_must_match(self):
+        header = self.bootstrap()
+        with self.assertRaisesRegex(ValueError, 'readback mismatch'):
+            changes.publish(self.out, header, '', lambda _: None, lambda *a: None)
+
+    def test_candidate_cli_needs_no_old_export_and_success_receipt_is_separate(self):
+        header = self.bootstrap()
+        candidate = self.folder(header) / 'manifest.json'
+        with patch.object(sys, 'argv', ['build-job-changes.py', '--out', str(self.out),
+                         '--candidate', str(candidate), '--publish-base', 'https://example.test']), \
+                patch.object(changes, 'build', side_effect=AssertionError('must not read exports')), \
+                patch.object(changes, 'publish', side_effect=RuntimeError('network failure')):
+            with self.assertRaises(RuntimeError): changes.main()
+        self.assertFalse((self.out / 'published.json').exists())
+        with patch.object(sys, 'argv', ['build-job-changes.py', '--out', str(self.out),
+                         '--candidate', str(candidate), '--publish-base', 'https://example.test']), \
+                patch.object(changes, 'publish'):
+            changes.main()
+        self.assertEqual(changes.read_json(self.out / 'published.json'), header)
+
+    def test_real_upstream_diff_visible_changes_removal_and_carry(self):
+        old = self.root / 'export/2026-09-08'; new = self.root / 'export/2026-09-09'
+        schema = {k: v for k, v in SCHEMA.items() if k not in
+                  ('op', 'from_date', 'to_date', 'removal', 'removed_at_crawler')}
+        schema.update({k: 'VARCHAR' for k in ('raw_json', 'detail_raw_json', 'enrichment_json', 'embedding')})
+        before = [self.job(str(i)) for i in range(8)] + [self.job('carry', slug='absent')]
+        before[6]['content'] = None
+        after = copy.deepcopy(before[:7])
+        after[6]['content'] = ''  # equivalent under upstream coalesce(content, '')
+        values = ['New title', 'Grand Junction, CO', 'https://example.test/moved',
+                  'New description', 'pending', datetime(2026, 9, 9, tzinfo=timezone.utc)]
+        for row, field, value in zip(after, ['title', 'location', 'url', 'content', 'embed_status', 'published_at'], values):
+            row[field] = value
+        self.parquet(old / 'jobs/example.parquet', before, schema)
+        self.parquet(new / 'jobs/example.parquet', after, schema)
+        ledger_schema = dict(ats='VARCHAR', slug='VARCHAR', id='VARCHAR', is_open='BOOLEAN', removed_at='TIMESTAMPTZ')
+        self.parquet(self.root / 'export/ledger/2026-09-09/data_0.parquet',
+                     [dict(ats='example', slug='company', id='7', is_open=False, removed_at=NOW)], ledger_schema)
+        diffs = self.root / 'export/diffs'; diffs.mkdir(parents=True)
+        (diffs / '2026-09-07__2026-09-08.json').write_bytes(changes.encode(
+            {'content_sha256': self.anchor['content_sha256']}))
+        proc = subprocess.run([sys.executable, str(Path(__file__).with_name('build-diff.py')),
+                               '--prev', str(old), '--new', str(new), '--out', str(self.root / 'export/diffs'),
+                               '--no-verify'], capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        side = changes.read_json(self.root / 'export/diffs/2026-09-08__2026-09-09.json')
+        self.assertEqual(side['counts'], {'added': 0, 'removed': 1, 'changed': 6, 'carried': 1})
+        self.assertEqual(side['removal'], {'closed': 1})
+        initial = self.bootstrap(before)
+        delta = changes.build(self.out, diff=diffs / '2026-09-08__2026-09-09.json', previous=initial)
+        self.assertEqual(delta['counts'], {'upsert': 6, 'remove': 1})
+        with sqlite3.connect(':memory:') as db:
+            for header in (initial, delta): changes.apply_generation(db, self.folder(header), header)
+            keys = {r[0] for r in db.execute('SELECT key FROM jobs')}
+            self.assertIn('example/absent#carry', keys)
+            self.assertNotIn('example/company#7', keys)
+            self.assertEqual(len(keys), 8)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Daily consumers need a small, verifiable change feed without downloading reclustered groups or full vectors. This adds an opt-in NDJSON page layer over the existing crawler-level lite diffs, rebased onto `57ba666`. It reuses the upstream removal reasons, posted-date tracking, part hashes and parent chain.

`added` and `changed` emit upserts; `removed` emits a removal with its ledger-derived reason and timestamp; `carried` and `changed_prev` emit nothing. The publisher validates completed sidecars, source continuity, hashes, counts, unique operations and paired change keys before creating a candidate. Pages retain the 1,000-row/4-MiB bounds, immutable hashed generations, stale-parent checks, upload-before-head ordering and final pointer readback. A saved candidate can be retried after old exports are pruned; the successful publication receipt is separate from the candidate head.

Bootstrap starts at September 8 or later and freezes a completed crawler export into pages tied to the matching index head, manifest timestamp and source diff hash. Subsequent builds need only the next lite diff and previous feed manifest. A fresh bootstrap provides an explicit recovery boundary for broken history; the SQLite reference consumer commits data and checkpoint atomically and rejects gaps or partial generations.

Scope is explicit: `crawler-export-v1`, including unembedded open jobs. Bootstrap uses the same source population as the deltas, rather than mixing a groups-only snapshot with broader crawler events. This does not claim exact search-group membership. Company names and other untracked board metadata are omitted; resolved company-name propagation would need upstream change tracking before being exposed. All six tracked mutable fields are projected, and null content is normalized consistently with the source change key. First-seen corrections require re-bootstrap.

The real diff integration fixture also exposed an ambiguous-column error in the removal/ledger join. This fixes it by qualifying the old-row columns.

Validation: all 16 tests pass on Windows/Python 3.11 and in `python:3.11-slim` with DuckDB 1.5.5. Fixtures exercise real parquet and the upstream diff SQL, field changes, removals, carry-forward, bootstrap/recovery, gaps, corrupt/incomplete/conflicting inputs, page limits, publication failures, stale parents, deterministic retry and transactional rollback. `git diff --check` passes. All upload tests use a fake store; no production publication, deployment or schedule change was performed. `backend/JOB-CHANGES.md` documents operation, costs, portability and the single-publisher requirement.
